### PR TITLE
 usr/sbin/init.c: Fixed problem for lack of sentinel value

### DIFF
--- a/usr/sbin/init/init.c
+++ b/usr/sbin/init/init.c
@@ -87,7 +87,7 @@ main(int argc, char *argv[])
 		dup(0);			/* stderr */
 
 		sys_log("init: running boot script\n");
-		execl(cmdbox, sh, runcom);
+		execl(cmdbox, sh, runcom,NULL);
 		sys_panic("init: no shell");
 	}
 


### PR DESCRIPTION
```
init was calling execl without a NULL as the last argument,
 this change is necessary to make it run with gcc-5.2.0.
```

Signed-off-by: Alejandro Lopez alexwinger@gmail.com
